### PR TITLE
go.mod: update go-xbps to fix issue with parsing revisions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Duncaen/go-xbps-src
 go 1.12
 
 require (
-	github.com/Duncaen/go-xbps v0.0.0-20190626161642-914cebb42ace
+	github.com/Duncaen/go-xbps v0.0.0-20220724153744-1f4ab16d608b
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Duncaen/go-xbps v0.0.0-20190626161642-914cebb42ace h1:fdOnucl2qRKzygkj9J2ra3MkvhDtANvXdBFtUcNgO8c=
 github.com/Duncaen/go-xbps v0.0.0-20190626161642-914cebb42ace/go.mod h1:QAnGsjHT5Xxov+QXfGGKPqn2FOHyWhErtnqU7GdiuJ8=
+github.com/Duncaen/go-xbps v0.0.0-20220724153744-1f4ab16d608b h1:wGpmhH4MmHkKHw2CNHXVsAxwFYJUp/u523NaeJVEubY=
+github.com/Duncaen/go-xbps v0.0.0-20220724153744-1f4ab16d608b/go.mod h1:QAnGsjHT5Xxov+QXfGGKPqn2FOHyWhErtnqU7GdiuJ8=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
`virtual?hunspell-en_GB` gets interpreted as

```
virtual?     (stripped)
    hunspell (pkgname)
    en       (version)
    GB       (revision)
```

until the fix in Duncaen/go-xbps@1f4ab16d608bb74acb589ab7a02e76b21d281afa
